### PR TITLE
added view helper for displaying a rating as stars

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,30 @@ module ApplicationHelper
   def render_price(price)
     return "%.2f" % price.floor(2)
   end
+  
+  def render_rating(rating)
+    return "no rating" unless rating
+    
+    filled_star = '<i class="fas fa-star"></i>'
+    empty_star = '<i class="far fa-star"></i>'
+    
+    # make a list of all the filled stars
+    star_list = []
+    until rating == 0
+      star_list << filled_star
+      rating -= 1
+    end
+    
+    # fill out the rest of the list with empty stars
+    until star_list.length == 5
+      star_list << empty_star
+    end
+    
+    # convert star list to string
+    stars = star_list.join("")
+    
+    return (
+      stars.html_safe
+    )
+  end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -30,4 +30,37 @@ describe ApplicationHelper do
       expect(result).must_equal "0.00"
     end
   end
+  
+  describe "render_rating" do
+    it "displays a rating of 5 as 5 filled stars" do
+      rating = 5
+      result = render_rating(rating)
+      expect(result).must_equal '<i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>'
+    end
+    
+    it "displays a rating of 3 as 3 filled stars and 2 empty" do
+      rating = 3
+      result = render_rating(rating)
+      expect(result).must_equal '<i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i>'
+    end
+    
+    it "displays a rating of 1 as 1 filled star and 4 empty" do
+      rating = 1
+      result = render_rating(rating)
+      # assert_dom_equal(%{<i class="fas fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i>}, result)
+      expect(result).must_equal '<i class="fas fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i><i class="far fa-star"></i>'
+    end
+    
+    it "returns 'no rating' if the rating is nil" do
+      rating = nil
+      result = render_rating(rating)
+      expect(result).must_equal "no rating"
+    end
+  end
 end
+
+# test "should return the user's full name" do
+#   user = users(:david)
+
+#   assert_dom_equal %{<a href="/user/#{user.id}">David Heinemeier Hansson</a>}, link_to_user(user)
+# end


### PR DESCRIPTION
I built a view helper for use with our reviews that will convert an integer rating into a string of font awesome filled and empty stars (so a rating of five is five filled stars, four is four filled stars and one empty star, etc)