### PR TITLE
Prevent merchants from reviewing their own products

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,10 +1,10 @@
 class ReviewsController < ApplicationController
   before_action :find_review, only: [:show]
-
+  
   def index
     @reviews = Review.all
   end
-
+  
   def new
     @review = Review.new
     @product_id = product_id_param
@@ -12,30 +12,40 @@ class ReviewsController < ApplicationController
   
   def show
   end
-
+  
   def create
-    review_info = {
-      comment: review_params[:comment],
-      rating: review_params[:rating],
-      product_id: product_id_param
-      }
-    @review = Review.new(review_info) 
-    if @review.save
-      flash[:success] = "Your review was successfully submitted."
-      redirect_to root_path
+    logged_in_id = logged_in?
+    product = Product.find_by(id: product_id_param)
+    
+    
+    if logged_in_id && logged_in_id == product.user_id
+      flash[:error] = "You cannot review your own product"
+      redirect_to product_path(product.id)
       return
     else
-      flash[:failure] = "Your review couldn't be submitted."
-      redirect_to root_path
-      return
+      review_info = {
+        comment: review_params[:comment],
+        rating: review_params[:rating],
+        product_id: product_id_param
+      }
+      @review = Review.new(review_info) 
+      if @review.save
+        flash[:success] = "Your review was successfully submitted."
+        redirect_to root_path
+        return
+      else
+        flash[:failure] = "Your review couldn't be submitted."
+        redirect_to root_path
+        return
+      end
     end
   end
-
+  
   private
   def review_params
-    params.require(:review).permit(:rating, :comment)
+    params.permit(:rating, :comment)
   end
-
+  
   def product_id_param
     params.require(:product_id)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,7 +75,7 @@
               <strong>A problem occurred:</strong>
             </div>
           <ul>
-            <% flash[:error].each do |name, message| %>
+            <% flash.each do |name, message| %>
               <li><%= name.capitalize %>: <%= message %></li>
             <% end %>
             </ul>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -48,5 +48,9 @@
       <% end %>
     </tbody>
   </table>
+
+  <% if session[:user_id].nil? || session[:user_id] != @product.user_id %>
+    <%=render partial: 'shared/review_form'%>
+  <% end %>
 </section>
 </main>

--- a/app/views/shared/_review_form.html.erb
+++ b/app/views/shared/_review_form.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <%= form_with model: @review, url: "/products/#{@product.id}/reviews", class: "review-input" do |form| %>
+    <div>
+      <div class="dropdown">
+        <label>Rating</label>
+        <%= form.number_field :rating, in: 1..5 %>
+      </div>
+      <div class="form-group">
+        <label>Comment</label>
+        <%= form.text_field :comment, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= form.submit "Submit", class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -14,4 +14,52 @@ describe ReviewsController do
       end
     end
   end
+  
+  describe "logged in user" do
+    describe "create" do
+      before do
+        user = users(:orchid)
+        perform_login(user)
+      end
+      
+      it "lets a logged in user review another user's product" do
+        params_hash = {
+          review: {
+            rating: 5,
+            comment: "great plant"
+          }
+        }
+        
+        # treeivy is not orchid's product
+        product = products(:treeivy)
+        
+        expect {
+          post product_reviews_path(product.id), params: params_hash
+        }.must_differ "Review.count", 1
+        
+        new_review = Review.last
+        expect(new_review.comment).must_equal params_hash[:review][:comment]
+        expect(new_review.rating).must_equal params_hash[:review][:rating]
+      end
+      
+      it "does not let a logged in user review their own product" do
+        params_hash = {
+          review: {
+            rating: 5,
+            comment: "great plant"
+          }
+        }
+        
+        # hollyhock is one of orchid's products
+        product = products(:hollyhock)
+        
+        expect {
+          post product_reviews_path(product.id), params: params_hash
+        }.wont_change "Review.count"
+        
+        must_redirect_to product_path(product.id)
+        expect(flash[:error]).must_equal "You cannot review your own product"
+      end
+    end
+  end
 end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -55,4 +55,3 @@ describe Review do
     end
   end
 end
-


### PR DESCRIPTION
I added some tests for reviews_controller#create, and modified method to check if the logged-in user matches the product seller before allowing them to create a review.

I also added an if statement around the display of the form to create a review on the product show page, which doesn't display the form at all if the seller matches the logged-in user.

This involved copy-pasting the existing review form into a /shared folder so it's accessible by the product show page.