### PR TITLE
removed unnecessary nil check

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -26,11 +26,7 @@ class Order < ApplicationRecord
     items = self.order_items
     count = nil
     
-    if items.nil?
-      count = 0
-    else
-      count = items.count
-    end
+    count = items.count
     
     return count
   end


### PR DESCRIPTION
Apparently when you create an Order, it creates an empty array for its list of order_items, instead of being nil, so I took out the nil-checking part of the method.